### PR TITLE
fix sniffer build on osx

### DIFF
--- a/make/Makefile.libpcap
+++ b/make/Makefile.libpcap
@@ -8,7 +8,7 @@ $(BUILD)/libpcap/configure:
 		$(TAR) zxf $(ROOT)/deps/libpcap-$(LIBPCAP_VERSION).tar.gz; \
 		mv libpcap-$(LIBPCAP_VERSION) libpcap
 
-ifneq "$(TARGET)" "native"
+ifneq (,$(findstring -linux-,$(TARGET)))
     LIBPCAP_CONFIG_FLAGS=--with-pcap=linux
 endif
 


### PR DESCRIPTION
Fixes `./pcap-linux.c:132:10: fatal error: 'linux/if.h' file not found` when running:
`make TARGET=x86_64-apple-darwin`